### PR TITLE
Add limit to search endpoint

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -149,8 +149,8 @@ paths:
       summary: Search games
       operationId: searchGames
       description: |
-        By passing in the appropriate options, you can search for
-        available inventory in the system
+        search for available games.
+        Returns entries from `pageNum * pageSize ... (pageNum + 1) * pageSize`.
       parameters:
         - in: query
           name: searchTerm
@@ -165,6 +165,15 @@ paths:
             type: integer
             format: int32
             minimum: 0
+        - in: query
+          name: pageSize
+          description: 'sets how many entries per page'
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 25
       responses:
         '200':
           description: at most 25 paged results
@@ -192,13 +201,25 @@ paths:
       parameters:
         - in: query
           name: searchString
-          description: pass an optional search string for looking up inventory
+          description: search term to return summary for
           required: true
           schema:
             type: string
+        - in: query
+          name: pageSize
+          description: |
+            how many results in a "page", so that number of pages 
+            can be calculated.
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 25
       responses:
         '200':
-          description: at most 25 paged results
+          description: summary of search if it were to be performed
           content:
             application/json:
               schema:


### PR DESCRIPTION
Add a limit query parameter to the search endpoint. The limit should
be at least 1, and at most 25
![image](https://user-images.githubusercontent.com/19290142/125385735-1480f900-e369-11eb-8d2b-aada43e9123d.png)
![image](https://user-images.githubusercontent.com/19290142/125385753-206cbb00-e369-11eb-89be-8a2c20be42de.png)
